### PR TITLE
0.3.0

### DIFF
--- a/lib/undercover/checkstyle/version.rb
+++ b/lib/undercover/checkstyle/version.rb
@@ -1,5 +1,5 @@
 module Undercover
   module Checkstyle
-    VERSION = "0.2.0"
+    VERSION = '0.3.0'
   end
 end

--- a/undercover-checkstyle.gemspec
+++ b/undercover-checkstyle.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'undercover', '>= 0.3.4'
+  spec.add_dependency 'rexml'
 end

--- a/undercover-checkstyle.gemspec
+++ b/undercover-checkstyle.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Undercover checkstyle reporter.}
   spec.homepage      = "https://github.com/aki77/undercover-checkstyle"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
rexml is no longer default gem in Ruby 3.0.